### PR TITLE
Patch daq_move_PI

### DIFF
--- a/src/pymodaq_plugins_physik_instrumente/daq_move_plugins/daq_move_PI.py
+++ b/src/pymodaq_plugins_physik_instrumente/daq_move_plugins/daq_move_PI.py
@@ -50,7 +50,7 @@ class DAQ_Move_PI(DAQ_Move_base):
 
     params = [
         {'title': 'Connection_type:', 'name': 'connect_type', 'type': 'list',
-         'value': 'USB', 'values': ConnectionEnum.names()},
+         'value': 'USB', 'limits': ConnectionEnum.names()},
         {'title': 'Devices:', 'name': 'devices', 'type': 'list', 'limits': devices},
         {'title': 'Daisy Chain Options:', 'name': 'dc_options', 'type': 'group', 'children': [
             {'title': 'Use Daisy Chain:', 'name': 'is_daisy', 'type': 'bool', 'value': False},
@@ -105,7 +105,7 @@ class DAQ_Move_PI(DAQ_Move_base):
 
         self.settings.child('controller_id').setValue(self.controller.identify())
         self.axis_names = self.controller.axis_names
-        self.controller.set_referencing(self.axis_name)
+        # self.controller.set_referencing(self.axis_name)
 
         # check servo status:
         self.settings.child('closed_loop').setValue(self.controller.get_servo(self.axis_name))


### PR DESCRIPTION
- changed values to limits (looks mandatory now)
- commented the set_reference in the init for two reasons: (1) it is currently broken for our two stages and (2) I don't think the referencing procedure (which moves the motor) should be started at each initialization! 
 
More work is needed to get the referencing procedure to work. Right now in our case, there seem to be an error when checking available attributes because it either tries to send open loop commands to a closed-loop-enabled stage (which is forbidden), or says that there is no sensor when sending closed-loop commands.